### PR TITLE
Fix dependency bug for inference

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,12 +37,12 @@ setup(
         "hydra-core >= 1.1.0",
         "hydra_colorlog >= 1.1.0",
         "tqdm",
+        "joblib",
     ],
     extras_require={
         "dev": [
             "torchmetrics",
             "scikit-learn",
-            "joblib",
             "docstr-coverage",
             "tensorboard",
             "matplotlib",


### PR DESCRIPTION
This PR fixed the bug regarding the dependency issue for `joblib`.
The inference codes require `joblib`, but `joblib` installed when `dev` extras are called.